### PR TITLE
Fix `iceberg.properties` to work with current Trino

### DIFF
--- a/iceberg/kafka-connect/iceberg.properties
+++ b/iceberg/kafka-connect/iceberg.properties
@@ -3,9 +3,10 @@ iceberg.catalog.type=rest
 iceberg.rest-catalog.uri=http://rest:8181
 iceberg.rest-catalog.warehouse=s3://demo-iceberg/
 iceberg.file-format=PARQUET
-# s3 in minio requires hive configuration
-# see also https://github.com/trinodb/trino/pull/16557
-hive.s3.endpoint=http://minio:9000
-hive.s3.path-style-access=true
+# https://trino.io/docs/current/object-storage/file-system-s3.html
+fs.native-s3.enabled=true
+s3.endpoint=http://minio:9000
+s3.region=eu-south-2
+s3.path-style-access=true
 #hive.s3.aws-access-key=admin
 #hive.s3.aws-secret-key=password


### PR DESCRIPTION
Without these changes, with current Trino versions, you get:

```
ERROR	main	io.trino.server.Server	Configuration errors:

1) Error: Configuration property 'hive.s3.endpoint' was not used

2) Error: Configuration property 'hive.s3.path-style-access' was not used

2 errors
io.airlift.bootstrap.ApplicationConfigurationException: Configuration errors:

1) Error: Configuration property 'hive.s3.endpoint' was not used

2) Error: Configuration property 'hive.s3.path-style-access' was not used

2 errors
	at io.airlift.bootstrap.Bootstrap.configure(Bootstrap.java:240)
	at io.airlift.bootstrap.Bootstrap.initialize(Bootstrap.java:269)
	at io.trino.plugin.iceberg.IcebergConnectorFactory.createConnector(IcebergConnectorFactory.java:119)
	at io.trino.plugin.iceberg.IcebergConnectorFactory.create(IcebergConnectorFactory.java:81)
	at io.trino.connector.DefaultCatalogFactory.createConnector(DefaultCatalogFactory.java:211)
	at io.trino.connector.DefaultCatalogFactory.createCatalog(DefaultCatalogFactory.java:128)
	at io.trino.connector.LazyCatalogFactory.createCatalog(LazyCatalogFactory.java:45)
	at io.trino.connector.StaticCatalogManager.lambda$loadInitialCatalogs$1(StaticCatalogManager.java:161)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:31)
	at java.base/java.util.concurrent.ExecutorCompletionService.submit(ExecutorCompletionService.java:186)
	at io.trino.util.Executors.executeUntilFailure(Executors.java:46)
	at io.trino.connector.StaticCatalogManager.loadInitialCatalogs(StaticCatalogManager.java:155)
	at io.trino.server.Server.doStart(Server.java:162)
	at io.trino.server.Server.lambda$start$0(Server.java:97)
	at io.trino.$gen.Trino_458____20240923_153902_1.run(Unknown Source)
	at io.trino.server.Server.start(Server.java:97)
	at io.trino.server.TrinoServer.main(TrinoServer.java:37)
```